### PR TITLE
update requirements to accept Elixir 0.10.x

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSON.Mixfile do
   def project do
     [ app: :json,
       version: "0.1.0",
-      elixir: "~> 0.9.4",
+      elixir: "~> 0.9.4 or ~> 0.10.0",
       deps: deps,
       source_url: "https://github.com/cblage/elixir-json" ]
   end


### PR DESCRIPTION
Thank you for elixir-json!

All 43 tests pass with Elixir 0.10.1, this pull request just allow 0.10.x releases of Elixir.
