### PR TITLE
fix encoding for string with \\

### DIFF
--- a/lib/json/encode.ex
+++ b/lib/json/encode.ex
@@ -128,7 +128,7 @@ defimpl JSON.Encode, for: BitString do
   defp encode_binary_character(?\r,  acc),  do: [?r, ?\\  | acc]
   defp encode_binary_character(?\t,  acc),  do: [?t, ?\\  | acc]
   defp encode_binary_character(?/,   acc),  do: [?/, ?\\  | acc]
-  defp encode_binary_character('\\', acc),  do: [?\\, ?\\ | acc]
+  defp encode_binary_character(?\\, acc),  do: [?\\, ?\\ | acc]
   defp encode_binary_character(char, acc) when is_number(char) and char < @acii_space do
     encode_hexadecimal_unicode_control_character(char, [?u,  ?\\ | acc])
   end

--- a/test/json_encode_test.exs
+++ b/test/json_encode_test.exs
@@ -38,4 +38,8 @@ defmodule JSONEncodeTest do
       == {:ok, "{\"array\":[\"a\",\"b\",\"c\"],\"false\":false,\"null\":null,\"number\":1234,\"object\":{\"omg\":1337,\"sub_sub_array\":[1,2,3],\"sub_sub_object\":{\"woot\":123}},\"string\":\"this will be a string\"}"}
   end
 
+  test "convert keyword with '\\' into correct JSON" do
+    assert \
+      JSON.encode([result: "\\n"]) == {:ok, "{\"result\":\"\\\\n\"}"}
+  end
 end


### PR DESCRIPTION
Hi. I was encoding the string with "\n" using elixir-json, and facing a behavior which is different from other json libraries. I'm not sure enough if it's a correct (intentional) or not, but trying to fix. What do you think?

elixir-json

```
iex(2)> JSON.encode!(["\n"])
"[\"\\n\"]"
iex(3)> JSON.encode!(["\\n"])
"[\"\\n\"]"
```

ruby 1.9.2

```
1.9.2-p290 :001 > require 'json'
 => true 
1.9.2-p290 :002 > JSON.generate(["\n"])
 => "[\"\\n\"]" 
1.9.2-p290 :003 > JSON.generate(["\\n"])
 => "[\"\\\\n\"]" 
```

Python 2.7.2

```
Python 2.7.2 (default, Oct 11 2012, 20:14:37) 
[GCC 4.2.1 Compatible Apple Clang 4.0 (tags/Apple/clang-418.0.60)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
>>> json.dumps(["\n"])
'["\\n"]'
>>> json.dumps(["\\n"])
'["\\\\n"]'
```
