### PR TITLE
apply latest application syntax

### DIFF
--- a/lib/json/encode.ex
+++ b/lib/json/encode.ex
@@ -69,7 +69,7 @@ defimpl JSON.Encode, for: List do
     if Keyword.keyword? list do 
       {:ok, "{" <> Enum.map_join(list, ",", fn {key, object} -> encode_item(key) <> ":" <>  encode_item(object) end) <> "}"}
     else
-      {:ok, "[" <> Enum.map_join(list, ",", encode_item(&1)) <> "]"}
+      {:ok, "[" <> Enum.map_join(list, ",", &encode_item(&1)) <> "]"}
     end
   end
 


### PR DESCRIPTION
Just for avoiding warning at elixir/master.

> lib/json/encode.ex:72: partial application without capture is deprecated

Elixir's change is the following,
https://github.com/elixir-lang/elixir/commit/9839bfa4adc783d0b73b7674c6a772ec5e702fed
