### PR TITLE
Update dependency for Elixir 0.12.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSON.Mixfile do
   def project do
     [ app: :json,
       version: "0.2.6",
-      elixir: "~> 0.11.0",
+      elixir: "~> 0.12.0",
       deps: deps,
       source_url: "https://github.com/cblage/elixir-json" ]
   end


### PR DESCRIPTION
Simple dependency update. All tests pass under `mix test`.
