### PR TITLE
Support maps, deserialize to maps instead of HashDict

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ end
 
 ```elixir
   JSON.decode("{\"result\":\"this will be a elixir result\"}")
-  {:ok, [result: "this will be a elixir result"]}
+  {:ok, %{"result" => "this will be a elixir result"}}
 ```
 
 ## Dynamo Filter

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -28,7 +28,7 @@ defmodule JSON do
   ## Examples
 
       iex> JSON.decode("{\\\"result\\\":\\\"this will be an Elixir result\\\"}")
-      {:ok, HashDict.new [{"result", "this will be an Elixir result"}]}
+      {:ok, %{"result" => "this will be an Elixir result"}}
   """
   @spec decode(bitstring) :: {atom, term}
   @spec decode(char_list) :: {atom, term}

--- a/lib/json/parse/bitstring.ex
+++ b/lib/json/parse/bitstring.ex
@@ -84,7 +84,7 @@ defmodule JSON.Parse.Bitstring do
         {:ok, ["foo", 1, 2, 1.5], " lala" }
 
         iex> JSON.Parse.Bitstring.Value.consume "{\\\"result\\\": \\\"this will be a elixir result\\\"} lalal"
-        {:ok, HashDict.new([{"result", "this will be a elixir result"}]), " lalal"}
+        {:ok, %{"result" => "this will be a elixir result"}, " lalal"}
     """
     def consume(<< ?[, _ :: binary >> = bin), do: JSON.Parse.Bitstring.Array.consume(bin)
     def consume(<< ?{, _ :: binary >> = bin), do: JSON.Parse.Bitstring.Object.consume(bin)
@@ -108,7 +108,7 @@ defmodule JSON.Parse.Bitstring do
 
   defmodule Object do
     @doc """
-    Consumes a valid JSON object value, returns its elixir HashDict representation
+    Consumes a valid JSON object value, returns its elixir map representation
 
     ## Examples
 
@@ -128,7 +128,7 @@ defmodule JSON.Parse.Bitstring do
         {:error, {:unexpected_token, "[\\\"foo\\\", 1, 2, 1.5] lala"}}
 
         iex> JSON.Parse.Bitstring.Object.consume "{\\\"result\\\": \\\"this will be a elixir result\\\"} lalal"
-        {:ok, HashDict.new([{"result", "this will be a elixir result"}]), " lalal"}
+        {:ok, %{"result" => "this will be a elixir result"}, " lalal"}
     """
     def consume(<< ?{, rest :: binary >>) do
       JSON.Parse.Bitstring.Whitespace.consume(rest) |> consume_object_contents
@@ -157,7 +157,7 @@ defmodule JSON.Parse.Bitstring do
       case JSON.Parse.Bitstring.Value.consume(after_key) do
         { :error, error_info } -> { :error, error_info }
         { :ok, value, after_value } ->
-          acc = HashDict.put(acc, key, value)
+          acc = Map.put(acc, key, value)
           after_value = JSON.Parse.Bitstring.Whitespace.consume(after_value)
           case after_value do
             << ?,, after_comma :: binary >> ->  
@@ -168,7 +168,7 @@ defmodule JSON.Parse.Bitstring do
       end
     end
 
-    defp consume_object_contents(json), do: consume_object_contents(HashDict.new, json)
+    defp consume_object_contents(json), do: consume_object_contents(%{}, json)
 
     defp consume_object_contents(acc, << ?", _ :: binary >> = bin) do
       case consume_object_key(bin) do

--- a/lib/json/parse/charlist.ex
+++ b/lib/json/parse/charlist.ex
@@ -80,7 +80,7 @@ defmodule JSON.Parse.Charlist do
         {:ok, ["foo", 1, 2, 1.5], ' lala' }
 
         iex> JSON.Parse.Charlist.Value.consume '{"result": "this will be a elixir result"} lalal'
-        {:ok, HashDict.new([{"result", "this will be a elixir result"}]), ' lalal'}
+        {:ok, %{"result" => "this will be a elixir result"}, ' lalal'}
     """
     def consume([ ?[ | _ ] = charlist), do: JSON.Parse.Charlist.Array.consume(charlist)
     def consume([ ?{ | _ ] = charlist), do: JSON.Parse.Charlist.Object.consume(charlist)
@@ -105,7 +105,7 @@ defmodule JSON.Parse.Charlist do
 
   defmodule Object do
     @doc """
-    Consumes a valid JSON object value, returns its elixir HashDict representation
+    Consumes a valid JSON object value, returns its elixir map representation
 
     ## Examples
 
@@ -122,7 +122,7 @@ defmodule JSON.Parse.Charlist do
         {:error, {:unexpected_token, '[]'}}
         
         iex> JSON.Parse.Charlist.Object.consume '{"result": "this will be a elixir result"} lalal'
-        {:ok, HashDict.new([{"result", "this will be a elixir result"}]), ' lalal'}
+        {:ok, %{"result" => "this will be a elixir result"}, ' lalal'}
     """
     def consume([ ?{ | rest ]) do
       JSON.Parse.Charlist.Whitespace.consume(rest) |> consume_object_contents
@@ -150,7 +150,7 @@ defmodule JSON.Parse.Charlist do
       case JSON.Parse.Charlist.Value.consume(after_key) do
         {:error, error_info} -> {:error, error_info}
         {:ok, value, after_value} ->
-          acc  = HashDict.put(acc, key, value)
+          acc  = Map.put(acc, key, value)
           after_value = JSON.Parse.Charlist.Whitespace.consume(after_value)
           case after_value do
             [ ?, | after_comma ] -> consume_object_contents(acc, JSON.Parse.Charlist.Whitespace.consume(after_comma))
@@ -159,7 +159,7 @@ defmodule JSON.Parse.Charlist do
       end
     end
     
-    defp consume_object_contents(json), do: consume_object_contents(HashDict.new, json)
+    defp consume_object_contents(json), do: consume_object_contents(%{}, json)
     
     defp consume_object_contents(acc, [ ?" | _ ] = list) do
       case consume_object_key(list) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSON.Mixfile do
   def project do
     [ app: :json,
       version: "0.3.0-dev",
-      elixir: "~> 0.12.0",
+      elixir: "~> 0.13.0-dev",
       deps: deps(Mix.env),
       source_url: "https://github.com/cblage/elixir-json",
       homepage_url: "http://expm.co/json" ]

--- a/test/json_decode_test.exs
+++ b/test/json_decode_test.exs
@@ -57,8 +57,8 @@ defmodule JSONDecodeTest do
     decodes "float with positive exponent", "-1.22783E+4", -12278.3
     decodes "float with negative exponent", "903.4e-6", 0.0009034
 
-    decodes "empty object", "{}", HashDict.new
-    decodes "simple object", "{\"result\": \"this is awesome\"}", HashDict.new([ { "result", "this is awesome" } ])
+    decodes "empty object", "{}", %{}
+    decodes "simple object", "{\"result\": \"this is awesome\"}", %{ "result" => "this is awesome" }
 
     decodes "empty array", "  [   ] ", []
     decodes "simple array", "[ 1, 2, \"three\", 4 ]", [ 1, 2, "three", 4 ]
@@ -75,16 +75,16 @@ defmodule JSONDecodeTest do
                 { "name": "Elga" }
               ]
              }',
-             HashDict.new([
-              { "name", "Jenny" },
-              { "active", true },
-              { "phone", "1.415.555.0000" },
-              { "balance", 1.52e+5 },
-              { "children", [
-                HashDict.new([ { "name", "Penny" } ]),
-                HashDict.new([ { "name", "Elga" } ])
-              ] }
-            ])
+             %{
+              "name" => "Jenny",
+              "active" => true,
+              "phone" => "1.415.555.0000",
+              "balance" => 1.52e+5,
+              "children" => [
+                %{ "name" => "Penny" },
+                %{ "name" => "Elga" }
+              ]
+            }
 
     decodes "complex object in bitstring",
             "{
@@ -97,16 +97,16 @@ defmodule JSONDecodeTest do
                 { \"name\": \"Éloise\" }
               ]
              }",
-             HashDict.new([
-              { "name", "Rafaëlla" },
-              { "active", true },
-              { "phone", "1.415.555.0000" },
-              { "balance", 1.52e+5 },
-              { "children", [
-                HashDict.new([ { "name", "Søren" } ]),
-                HashDict.new([ { "name", "Éloise" } ])
-              ] }
-            ])
+             %{
+              "name" => "Rafaëlla",
+              "active" => true,
+              "phone" => "1.415.555.0000",
+              "balance" => 1.52e+5,
+              "children" => [
+                %{ "name" => "Søren" },
+                %{ "name" => "Éloise" }
+              ]
+            }
 
     cannot_decode "bad literal", "nul", {:unexpected_token, "nul"}
 

--- a/test/json_encode_test.exs
+++ b/test/json_encode_test.exs
@@ -38,6 +38,20 @@ defmodule JSONEncodeTest do
       == {:ok, "{\"number\":1234,\"false\":false,\"array\":[\"a\",\"b\",\"c\"],\"object\":{\"omg\":1337,\"sub_sub_array\":[1,2,3],\"sub_sub_object\":{\"woot\":123}},\"null\":null,\"string\":\"this will be a string\"}"}
   end
 
+  test "convert map into correct JSON" do
+    acc = Map.new
+    acc = Map.put(acc, "null",  nil)
+    acc = Map.put(acc, "false", false)
+    acc = Map.put(acc, "string", "this will be a string")
+    acc = Map.put(acc, "number", 1234)
+    acc = Map.put(acc, "array",  ["a", :b, "c"])
+    acc = Map.put(acc, "object", [omg: 1337, sub_sub_array: [1,2,3], sub_sub_object: [woot: 123]])
+
+
+    assert JSON.encode(acc) \
+      == {:ok, "{\"array\":[\"a\",\"b\",\"c\"],\"false\":false,\"null\":null,\"number\":1234,\"object\":{\"omg\":1337,\"sub_sub_array\":[1,2,3],\"sub_sub_object\":{\"woot\":123}},\"string\":\"this will be a string\"}"}
+  end
+
   test "convert keyword with '\\' into correct JSON" do
     assert \
       JSON.encode([result: "\\n"]) == {:ok, "{\"result\":\"\\\\n\"}"}


### PR DESCRIPTION
In order to get a little experience with maps I've made a patch that makes elixir-json use maps as the primary translation of objects. HashDicts are still accepted as inputs.

This is based on the v0.13 branch of Elixir (which requires Erlang R17 to be installed) and the parser-decoder-decoupling branch of elixir-json as it seemed that's where most of the development effort is being done.

I hope this will be useful.
