### PR TITLE
fixes compilation error on Elixir v0.13

### DIFF
--- a/lib/json/numeric.ex
+++ b/lib/json/numeric.ex
@@ -107,7 +107,7 @@ defmodule JSON.Numeric do
   end
 
   def to_integer_from_hex(iolist) when is_list(iolist) do
-    if Regex.match?(%r{^[0-9a-fA-F]}, iolist) do
+    if Regex.match?(~r/^[0-9a-fA-F]/, iolist_to_binary(iolist)) do
       to_integer_from_hex_recursive(iolist, 0)
     else
       :error

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule JSON.Mixfile do
   def project do
     [ app: :json,
       version: "0.2.7",
-      elixir: "~> 0.12.0",
+      elixir: "~> 0.12",
       deps: deps,
       source_url: "https://github.com/cblage/elixir-json" ]
   end


### PR DESCRIPTION
when compiling on Elixir v0.13 a compilation error occurs on file
lib/json/numeric.ex. This is due to the changed sigil syntax for regular
expressions.

Also the Regex.match?/2 function no longer accepts IOLists, only binary
strings.
