### PR TITLE
Encodes maps into object

### DIFF
--- a/lib/json/encode.ex
+++ b/lib/json/encode.ex
@@ -137,6 +137,13 @@ defimpl JSON.Encode, for: Record do
   def typeof(_), do: :object
 end
 
+# Encodes maps into object
+# > {:ok, "{\"a\":1,\"b\":2}"} = JSON.encode(%{a: 1, b: 2})
+defimpl JSON.Encode, for: Map do
+  def to_json(map), do: map |> JSON.Encode.Helpers.dict_to_json
+  def typeof(_), do: :object
+end
+
 #TODO: maybe this should return the result of "inspect" ?
 defimpl JSON.Encode, for: Any do
   @any_to_json "[Elixir.Any]"

--- a/test/json_encode_test.exs
+++ b/test/json_encode_test.exs
@@ -42,4 +42,10 @@ defmodule JSONEncodeTest do
     assert \
       JSON.encode([result: "\\n"]) == {:ok, "{\"result\":\"\\\\n\"}"}
   end
+
+  test "convert maps into correct JSON" do
+    assert \
+      JSON.encode(%{a: 1, b: %{b1: 21}}) |> IO.inspect \
+      == {:ok, "{\"a\":1,\"b\":{\"b1\":21}}"}
+  end
 end


### PR DESCRIPTION
as in master branch, added an implementation to encode maps

``` elixir
> {:ok, "{\"a\":1,\"b\":2}"} = JSON.encode(%{a: 1, b: 2})
```
