### PR TITLE
Make elixir-json compatible with elixir v0.14.1

### DIFF
--- a/lib/json/decode.ex
+++ b/lib/json/decode.ex
@@ -1,12 +1,10 @@
 defmodule JSON.Decode do
-
-  defexception Error, message: "Invalid JSON - unknown error"
-
-  defexception UnexpectedTokenError, token: nil do
+  defmodule Error, do: defexception([message: "Invalid JSON - unknown error"])
+  defmodule UnexpectedEndOfBufferError, do: defexception([message: "Invalid JSON - unexpected end of buffer"])
+  defmodule UnexpectedTokenError do
+    defexception [token: nil]
     def message(exception), do: "Invalid JSON - unexpected token >>#{exception.token}<<"
   end
-
-  defexception UnexpectedEndOfBufferError, message: "Invalid JSON - unexpected end of buffer"
 
   #32 = ascii space, cleaner than using "? ", I think
   @acii_space 32
@@ -19,9 +17,9 @@ defmodule JSON.Decode do
   defp consume_whitespace(iolist) when is_list(iolist), do: iolist
 
   def from_json(bitstring) when is_binary(bitstring) do
-    case bitstring_to_list(bitstring) |> from_json do
+    case :erlang.bitstring_to_list(bitstring) |> from_json do
       { :ok, value } -> { :ok, value }
-      { :unexpected_token, tok }       -> { :unexpected_token, iodata_to_binary(tok) }
+      { :unexpected_token, tok }       -> { :unexpected_token, IO.iodata_to_binary(tok) }
       { :unexpected_end_of_buffer, s } -> { :unexpected_end_of_buffer, s }
     end
   end
@@ -132,7 +130,7 @@ defmodule JSON.Decode do
   defp consume_string_contents({ :unexpected_token, s }),         do: { :unexpected_token, s }
   defp consume_string_contents({ :unexpected_end_of_buffer, s }), do: { :unexpected_end_of_buffer, s }
   defp consume_string_contents({ _,  [] }),                       do: { :unexpected_end_of_buffer, "" }
-  defp consume_string_contents({ acc, [ ?" | rest ] }), do: {:ok, Enum.reverse(acc) |> iodata_to_binary, rest }
+  defp consume_string_contents({ acc, [ ?" | rest ] }), do: {:ok, Enum.reverse(acc) |> IO.iodata_to_binary, rest }
 
   #parsing
   defp consume_string_contents({ acc, [ ?\\, ?f  | rest ]}), do: consume_string_contents({ [ ?\f | acc ], rest })

--- a/lib/json/encode.ex
+++ b/lib/json/encode.ex
@@ -1,7 +1,8 @@
-defexception JSON.Encode.Error, error_info: nil do
+defmodule JSON.Encode.Error do
+  defexception [error_info: nil]
+
   def message(exception) do
     error_message = "An error occurred while encoding the JSON object"
-
     if nil != exception.error_info  do
       error_message <> " >>#{exception.error_info}<<"
     else
@@ -42,7 +43,7 @@ defprotocol JSON.Encode do
 end
 
 defimpl JSON.Encode, for: Tuple do
-  def to_json(term), do: tuple_to_list(term) |> JSON.Encode.to_json
+  def to_json(term), do: Tuple.to_list(term) |> JSON.Encode.to_json
   def typeof(_), do: :array
 end
 
@@ -102,7 +103,7 @@ defimpl JSON.Encode, for: Atom do
   def to_json(nil), do: {:ok, "null"}
   def to_json(false), do: {:ok, "false"}
   def to_json(true),  do: {:ok, "true"}
-  def to_json(atom) when is_atom(atom), do: atom_to_binary(atom) |> JSON.Encode.to_json
+  def to_json(atom) when is_atom(atom), do: Atom.to_string(atom) |> JSON.Encode.to_json
 
   def typeof(boolean) when is_boolean(boolean), do: :boolean
   def typeof(nil), do: :null
@@ -138,7 +139,7 @@ defimpl JSON.Encode, for: BitString do
   defp encode_binary_character(char, acc) when is_number(char), do: [ char | acc ]
 
   defp encode_hexadecimal_unicode_control_character(char, acc) when is_number(char) do
-    [integer_to_list(char, 16) |> zeropad_hexadecimal_unicode_control_character |> Enum.reverse | acc]
+    [Integer.to_char_list(char, 16) |> zeropad_hexadecimal_unicode_control_character |> Enum.reverse | acc]
   end
 
   defp zeropad_hexadecimal_unicode_control_character([a, b, c]), do: [?0,  a,  b, c]

--- a/lib/json/numeric.ex
+++ b/lib/json/numeric.ex
@@ -39,8 +39,8 @@ defmodule JSON.Numeric do
   end
 
   def to_numeric(bitstring) when is_binary(bitstring) do
-    case bitstring_to_list(bitstring) |> to_numeric do
-      { result, rest } -> {result, iodata_to_binary(rest)}
+    case :erlang.bitstring_to_list(bitstring) |> to_numeric do
+      { result, rest } -> {result, IO.iodata_to_binary(rest)}
       :error -> :error
     end
   end
@@ -100,14 +100,14 @@ defmodule JSON.Numeric do
       { 3119, "reezing" }
   """
   def to_integer_from_hex(bitstring) when is_binary(bitstring) do
-    case bitstring_to_list(bitstring) |> to_integer_from_hex do
-      { result, rest } -> {result, iodata_to_binary(rest)}
+    case :erlang.bitstring_to_list(bitstring) |> to_integer_from_hex do
+      { result, rest } -> {result, IO.iodata_to_binary(rest)}
       :error -> :error
     end
   end
 
   def to_integer_from_hex(iolist) when is_list(iolist) do
-    if Regex.match?(~r/^[0-9a-fA-F]/, iodata_to_binary(iolist)) do
+    if Regex.match?(~r/^[0-9a-fA-F]/, IO.iodata_to_binary(iolist)) do
       to_integer_from_hex_recursive(iolist, 0)
     else
       :error


### PR DESCRIPTION
Hello,
There are some changes needed in order to make elixir-json compatible with elixir v0.14.1/v0.14.2
- defexception does not define the module itself anymore
- function renaming
