### PR TITLE
The JSON RFC does not require escaping '/'

### DIFF
--- a/lib/json/encoder.ex
+++ b/lib/json/encoder.ex
@@ -112,7 +112,6 @@ defimpl JSON.Encoder, for: BitString do
   defp encode_binary_character(?\n,  acc),  do: [?n, ?\\  | acc]
   defp encode_binary_character(?\r,  acc),  do: [?r, ?\\  | acc]
   defp encode_binary_character(?\t,  acc),  do: [?t, ?\\  | acc]
-  defp encode_binary_character(?/,   acc),  do: [?/, ?\\  | acc]
   defp encode_binary_character(?\\,  acc),  do: [?\\, ?\\ | acc]
   defp encode_binary_character(char, acc) when is_number(char) and char < @acii_space do
     encode_hexadecimal_unicode_control_character(char, [?u,  ?\\ | acc])

--- a/test/json_encode_test.exs
+++ b/test/json_encode_test.exs
@@ -43,6 +43,11 @@ defmodule JSONEncodeTest do
       JSON.encode([result: "\\n"]) == {:ok, "{\"result\":\"\\\\n\"}"}
   end
 
+  test "convert keyword with '/' into correct JSON" do
+    assert \
+      JSON.encode([result: "foo/"]) == {:ok, "{\"result\":\"foo/\"}"}
+  end
+
   test "convert maps into correct JSON" do
     assert \
       JSON.encode(%{a: 1, b: %{b1: 21}}) == {:ok, "{\"a\":1,\"b\":{\"b1\":21}}"}


### PR DESCRIPTION
As I mentioned in #24, I think an option for escaping characters not required to be escaped by the JSON spec is premature, but if you think it should be there I can add it.

FWIW here's the relevant section from the spec:

> All Unicode characters may be placed within the
>    quotation marks except for the characters that must be escaped:
>    quotation mark, reverse solidus, and the control characters (U+0000
>    through U+001F).
