### PR TITLE
fix charlist warnings

### DIFF
--- a/lib/json.ex
+++ b/lib/json.ex
@@ -34,13 +34,13 @@ defmodule JSON do
       {:ok, Enum.into([{"result", "this will be an Elixir result"}], Map.new) }
   """
   @spec decode(bitstring) :: {atom, term}
-  @spec decode(char_list) :: {atom, term}
+  @spec decode(charlist) :: {atom, term}
   def decode(bitstring_or_char_list) do
     JSON.Decoder.decode(bitstring_or_char_list)
   end
 
   @spec decode!(bitstring) :: term
-  @spec decode!(char_list) :: term
+  @spec decode!(charlist) :: term
   def decode!(bitstring_or_char_list) do
     case decode(bitstring_or_char_list) do
       { :ok, value } -> value

--- a/lib/json/encoder.ex
+++ b/lib/json/encoder.ex
@@ -127,7 +127,7 @@ defimpl JSON.Encoder, for: BitString do
   defp encode_binary_character(char, acc) when is_number(char), do: [ char | acc ]
 
   defp encode_hexadecimal_unicode_control_character(char, acc) when is_number(char) do
-    [Integer.to_char_list(char, 16) |> zeropad_hexadecimal_unicode_control_character |> Enum.reverse | acc]
+    [Integer.to_charlist(char, 16) |> zeropad_hexadecimal_unicode_control_character |> Enum.reverse | acc]
   end
 
   defp zeropad_hexadecimal_unicode_control_character([a, b, c]), do: [?0,  a,  b, c]


### PR DESCRIPTION
Fix warnings

```Compiling 15 files (.ex)
warning: the char_list() type is deprecated, use charlist()
  lib/json.ex:43

warning: the char_list() type is deprecated, use charlist()
  lib/json.ex:37

```
