### PR TITLE
Typespec fix for JSON.Encoder.encode

### DIFF
--- a/lib/json/encoder.ex
+++ b/lib/json/encoder.ex
@@ -29,7 +29,7 @@ defprotocol JSON.Encoder do
       {:ok, "{\\\"result\\\":\\\"this will be a elixir result\\\"}"}
 
   """
-  @spec encode(term) :: bitstring
+  @spec encode(term) :: {atom, bitstring}
   def encode(term)
 
   @doc """


### PR DESCRIPTION
Dialyzer picked this up when using `JSON.encode/1` in another project. Because it proxies to `JSON.Encode.encode/1`, the typespec for `JSON.Encoder.encode/1` being incorrect caused dialyzer to complain about `JSON.encode/1`.

For reference, this is the relevant `mix dialyzer` output after adding dialyzer to the project:
```
lib/json.ex:13: Invalid type specification for function 'Elixir.JSON':encode/1. The success typing is (_) -> bitstring()
lib/json.ex:19: Function 'encode!'/1 has no local return
lib/json.ex:21: The pattern {'ok', Vvalue@1} can never match the type bitstring()
lib/json.ex:22: The pattern {'error', Verror_info@1} can never match the type bitstring()
lib/json/encoder.ex:50: The inferred return type of encode/1 ({'ok',<<_:16,_:_*8>>}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:56: The inferred return type of encode/1 ({'ok',<<_:16,_:_*8>>}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:62: The inferred return type of encode/1 ({'ok',<<_:16,_:_*8>>}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:85: The inferred return type of encode/1 ({'ok',binary()}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:85: The inferred return type of encode/1 ({'ok',binary()}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:85: The inferred return type of encode/1 ({'ok',binary()}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:106: The inferred return type of encode/1 ({'ok',binary()}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:143: The inferred return type of encode/1 ({'ok',<<_:16,_:_*8>>}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:151: The inferred return type of encode/1 ({'ok',<<_:16,_:_*8>>}) has nothing in common with bitstring(), which is the expected return type for the callback of the 'Elixir.JSON.Encoder' behaviour
lib/json/encoder.ex:196: The pattern {'ok', Vencoded_item@1} can never match the type bitstring()
```