### PR TITLE
Handle Integer.parse :error result

### DIFF
--- a/lib/json/parser/bitstring/number.ex
+++ b/lib/json/parser/bitstring/number.ex
@@ -90,6 +90,7 @@ defmodule JSON.Parser.Bitstring.Number do
 
   defp to_integer(binary) do
     case Integer.parse(binary) do
+      :error -> { :error, { :unexpected_token, binary } }
       { :error, _ } -> { :error, { :unexpected_token, binary } }
       { result, rest } -> {:ok, result, rest}
     end


### PR DESCRIPTION
According to the documentation and IEX, `Integer.parse` will return `:error` when parsing fails, not `{:error, _}`. Maybe this was a return signature in an older version of Elixir, but in 1.6.0 `:error` is what needs to be supported. Because I'm unsure about older version, I've left the `{:error, _}` result in, despite dialyzer complaining that it is not required.