### PR TITLE
introducing log level filtering only for json library

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,18 @@ Decoding a list from a string that contains JSON
   # "this will be a value"
 ```
 
+At any time, you can turn on verbose logging for this library only. 
+To do so, head to config file of your application and add below lines:
+
+```elixir
+use Mix.Config
+
+config :logger, level: :debug
+
+config :json, log_level: :debug
+```
+
+Note that, changing only `:logger` level to `:info`, `:warn` or `:error` will silent `:json` too.
+
 # License
 The Elixir JSON library is available under the [BSD 3-Clause aka "BSD New" license](http://www.tldrlegal.com/l/BSD3)

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,3 +5,5 @@ use Mix.Config
 config :logger,
        level: :info,
        compile_time_purge_level: :debug
+
+config :json, log_level: :info

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -4,7 +4,7 @@ defmodule JSON do
   """
 
   require Logger
-  import Json.Logger
+  import JSON.Logger
 
   alias JSON.Encoder, as: Encoder
   alias JSON.Decoder, as: Decoder

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -56,16 +56,16 @@ defmodule JSON do
       Decoder.decode() |>
       case  do
        res = {:ok, _} ->
-        log(:debug, "#{__MODULE__}.decode(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect res}")
+        debug("#{__MODULE__}.decode(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect res}")
          res
        e = {:error, {:unexpected_token, tok}} ->
-         log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
+         debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
          e
        e = {:error, :unexpected_end_of_buffer} ->
-         log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
+         debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
          e
        e ->
-         log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
+         debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
      end
   end
 
@@ -82,16 +82,16 @@ defmodule JSON do
   def decode!(bitstring_or_char_list) do
     case Decoder.decode(bitstring_or_char_list) do
       {:ok, value} ->
-        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect value}")
+        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect value}")
         value
       {:error, {:unexpected_token, tok}} ->
-        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
+        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
         raise JSON.Decoder.UnexpectedTokenError, token: tok
       {:error, :unexpected_end_of_buffer} ->
-        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
+        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
         raise JSON.Decoder.UnexpectedEndOfBufferError
       e ->
-        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
+        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
     end
   end
 end

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -56,16 +56,16 @@ defmodule JSON do
       Decoder.decode() |>
       case  do
        res = {:ok, _} ->
-        debug("#{__MODULE__}.decode(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect res}")
+        log(:debug, fn -> "#{__MODULE__}.decode(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect res}" end)
          res
        e = {:error, {:unexpected_token, tok}} ->
-         debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
+         log(:debug, fn -> "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}" end)
          e
        e = {:error, :unexpected_end_of_buffer} ->
-         debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
+         log(:debug, fn -> "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer" end)
          e
        e ->
-         debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
+         log(:debug, fn -> "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}" end)
      end
   end
 
@@ -82,16 +82,16 @@ defmodule JSON do
   def decode!(bitstring_or_char_list) do
     case Decoder.decode(bitstring_or_char_list) do
       {:ok, value} ->
-        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect value}")
+        log(:debug, fn -> "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect value}" end)
         value
       {:error, {:unexpected_token, tok}} ->
-        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
+        log(:debug, fn -> "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}" end)
         raise JSON.Decoder.UnexpectedTokenError, token: tok
       {:error, :unexpected_end_of_buffer} ->
-        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
+        log(:debug, fn -> "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer" end)
         raise JSON.Decoder.UnexpectedEndOfBufferError
       e ->
-        debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
+        log(:debug, fn -> "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}" end)
     end
   end
 end

--- a/lib/json.ex
+++ b/lib/json.ex
@@ -4,6 +4,7 @@ defmodule JSON do
   """
 
   require Logger
+  import Json.Logger
 
   alias JSON.Encoder, as: Encoder
   alias JSON.Decoder, as: Decoder
@@ -55,16 +56,16 @@ defmodule JSON do
       Decoder.decode() |>
       case  do
        res = {:ok, _} ->
-         Logger.debug("#{__MODULE__}.decode(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect res}")
+        log(:debug, "#{__MODULE__}.decode(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect res}")
          res
        e = {:error, {:unexpected_token, tok}} ->
-         Logger.debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
+         log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
          e
        e = {:error, :unexpected_end_of_buffer} ->
-         Logger.debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
+         log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
          e
        e ->
-         Logger.debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
+         log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
      end
   end
 
@@ -81,16 +82,16 @@ defmodule JSON do
   def decode!(bitstring_or_char_list) do
     case Decoder.decode(bitstring_or_char_list) do
       {:ok, value} ->
-        Logger.debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect value}")
+        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} was sucesfull: #{inspect value}")
         value
       {:error, {:unexpected_token, tok}} ->
-        Logger.debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
+        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} unexpected token #{tok}")
         raise JSON.Decoder.UnexpectedTokenError, token: tok
       {:error, :unexpected_end_of_buffer} ->
-        Logger.debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
+        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} end of buffer")
         raise JSON.Decoder.UnexpectedEndOfBufferError
       e ->
-        Logger.debug("#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
+        log(:debug, "#{__MODULE__}.decode!(#{inspect bitstring_or_char_list}} an unknown problem occurred #{inspect e}")
     end
   end
 end

--- a/lib/json/decoder.ex
+++ b/lib/json/decoder.ex
@@ -37,23 +37,23 @@ defmodule JSON.Decoder.DefaultImplementations do
 
     """
     def decode(bitstring) do
-      debug("#{__MODULE__}.decode(#{inspect bitstring}) starting...")
+      log(:debug, fn -> "#{__MODULE__}.decode(#{inspect bitstring}) starting..." end)
       bitstring
       |> String.trim()
       |> Parser.parse()
       |> case do
            {:error, error_info} ->
-              debug("#{__MODULE__}.decode(#{inspect bitstring}} failed with errror: #{inspect error_info}")
+              log(:debug, fn -> "#{__MODULE__}.decode(#{inspect bitstring}} failed with errror: #{inspect error_info}" end)
               {:error, error_info}
            {:ok, value, rest} ->
-             debug("#{__MODULE__}.decode(#{inspect bitstring}) trimming remainder of JSON payload #{inspect rest}...")
+             log(:debug, fn -> "#{__MODULE__}.decode(#{inspect bitstring}) trimming remainder of JSON payload #{inspect rest}..." end)
              case rest |> String.trim() do
                <<>> ->
-                 debug("#{__MODULE__}.decode(#{inspect bitstring}) successfully trimmed remainder JSON payload!")
-                 debug("#{__MODULE__}.decode(#{inspect bitstring}) returning {:ok. #{inspect value}}")
+                 log(:debug, fn -> "#{__MODULE__}.decode(#{inspect bitstring}) successfully trimmed remainder JSON payload!" end)
+                 log(:debug, fn -> "#{__MODULE__}.decode(#{inspect bitstring}) returning {:ok. #{inspect value}}" end)
                  {:ok, value}
                rest ->
-                 debug("#{__MODULE__}.decode(#{inspect bitstring}} failed consume entire buffer: #{rest}")
+                 log(:debug, fn -> "#{__MODULE__}.decode(#{inspect bitstring}} failed consume entire buffer: #{rest}" end)
                  {:error, {:unexpected_token, rest}}
              end
          end
@@ -89,13 +89,13 @@ defmodule JSON.Decoder.DefaultImplementations do
         case do
           {:ok, value} -> {:ok, value}
           {:error, error_info} when is_binary(error_info)  ->
-            debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect error_info}")
+            log(:debug, fn -> "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect error_info}" end)
             {:error, error_info |> to_charlist()}
           {:error, {:unexpected_token, bin}} when is_binary(bin)  ->
-            debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect bin}")
+            log(:debug, fn -> "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect bin}" end)
             {:error, {:unexpected_token, bin |> to_charlist()}}
           e = {:error, error_info} ->
-            debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect e}")
+            log(:debug, fn -> "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect e}" end)
             {:error, error_info}
         end
     end

--- a/lib/json/decoder.ex
+++ b/lib/json/decoder.ex
@@ -12,6 +12,7 @@ end
 
 defmodule JSON.Decoder.DefaultImplementations do
   require Logger
+  import Json.Logger
 
   defimpl JSON.Decoder, for: BitString do
     @moduledoc """
@@ -36,23 +37,23 @@ defmodule JSON.Decoder.DefaultImplementations do
 
     """
     def decode(bitstring) do
-      Logger.debug("#{__MODULE__}.decode(#{inspect bitstring}) starting...")
+      log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) starting...")
       bitstring
       |> String.trim()
       |> Parser.parse()
       |> case do
            {:error, error_info} ->
-              Logger.debug("#{__MODULE__}.decode(#{inspect bitstring}} failed with errror: #{inspect error_info}")
+              log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}} failed with errror: #{inspect error_info}")
               {:error, error_info}
            {:ok, value, rest} ->
-             Logger.debug("#{__MODULE__}.decode(#{inspect bitstring}) trimming remainder of JSON payload #{inspect rest}...")
+             log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) trimming remainder of JSON payload #{inspect rest}...")
              case rest |> String.trim() do
                <<>> ->
-                 Logger.debug("#{__MODULE__}.decode(#{inspect bitstring}) successfully trimmed remainder JSON payload!")
-                 Logger.debug("#{__MODULE__}.decode(#{inspect bitstring}) returning {:ok. #{inspect value}}")
+                 log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) successfully trimmed remainder JSON payload!")
+                 log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) returning {:ok. #{inspect value}}")
                  {:ok, value}
                rest ->
-                 Logger.debug("#{__MODULE__}.decode(#{inspect bitstring}} failed consume entire buffer: #{rest}")
+                 log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}} failed consume entire buffer: #{rest}")
                  {:error, {:unexpected_token, rest}}
              end
          end
@@ -88,13 +89,13 @@ defmodule JSON.Decoder.DefaultImplementations do
         case do
           {:ok, value} -> {:ok, value}
           {:error, error_info} when is_binary(error_info)  ->
-            Logger.debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect error_info}")
+            log(:debug, "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect error_info}")
             {:error, error_info |> to_charlist()}
           {:error, {:unexpected_token, bin}} when is_binary(bin)  ->
-            Logger.debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect bin}")
+            log(:debug, "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect bin}")
             {:error, {:unexpected_token, bin |> to_charlist()}}
           e = {:error, error_info} ->
-            Logger.debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect e}")
+            log(:debug, "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect e}")
             {:error, error_info}
         end
     end

--- a/lib/json/decoder.ex
+++ b/lib/json/decoder.ex
@@ -37,23 +37,23 @@ defmodule JSON.Decoder.DefaultImplementations do
 
     """
     def decode(bitstring) do
-      log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) starting...")
+      debug("#{__MODULE__}.decode(#{inspect bitstring}) starting...")
       bitstring
       |> String.trim()
       |> Parser.parse()
       |> case do
            {:error, error_info} ->
-              log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}} failed with errror: #{inspect error_info}")
+              debug("#{__MODULE__}.decode(#{inspect bitstring}} failed with errror: #{inspect error_info}")
               {:error, error_info}
            {:ok, value, rest} ->
-             log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) trimming remainder of JSON payload #{inspect rest}...")
+             debug("#{__MODULE__}.decode(#{inspect bitstring}) trimming remainder of JSON payload #{inspect rest}...")
              case rest |> String.trim() do
                <<>> ->
-                 log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) successfully trimmed remainder JSON payload!")
-                 log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}) returning {:ok. #{inspect value}}")
+                 debug("#{__MODULE__}.decode(#{inspect bitstring}) successfully trimmed remainder JSON payload!")
+                 debug("#{__MODULE__}.decode(#{inspect bitstring}) returning {:ok. #{inspect value}}")
                  {:ok, value}
                rest ->
-                 log(:debug, "#{__MODULE__}.decode(#{inspect bitstring}} failed consume entire buffer: #{rest}")
+                 debug("#{__MODULE__}.decode(#{inspect bitstring}} failed consume entire buffer: #{rest}")
                  {:error, {:unexpected_token, rest}}
              end
          end
@@ -89,13 +89,13 @@ defmodule JSON.Decoder.DefaultImplementations do
         case do
           {:ok, value} -> {:ok, value}
           {:error, error_info} when is_binary(error_info)  ->
-            log(:debug, "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect error_info}")
+            debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect error_info}")
             {:error, error_info |> to_charlist()}
           {:error, {:unexpected_token, bin}} when is_binary(bin)  ->
-            log(:debug, "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect bin}")
+            debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect bin}")
             {:error, {:unexpected_token, bin |> to_charlist()}}
           e = {:error, error_info} ->
-            log(:debug, "#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect e}")
+            debug("#{__MODULE__}.decode(#{inspect charlist}} failed with errror: #{inspect e}")
             {:error, error_info}
         end
     end

--- a/lib/json/decoder.ex
+++ b/lib/json/decoder.ex
@@ -12,7 +12,7 @@ end
 
 defmodule JSON.Decoder.DefaultImplementations do
   require Logger
-  import Json.Logger
+  import JSON.Logger
 
   defimpl JSON.Decoder, for: BitString do
     @moduledoc """

--- a/lib/json/logger.ex
+++ b/lib/json/logger.ex
@@ -1,4 +1,4 @@
-defmodule Json.Logger do
+defmodule JSON.Logger do
   @moduledoc """
   Exposes separate log level configuration so developers can set logging
   verbosity for json library
@@ -40,7 +40,7 @@ defmodule Json.Logger do
   """
   defmacro log(level, message) do
     quote bind_quoted: [level: level, message: message] do
-      if level in Json.Logger.allowed_levels() do
+      if level in JSON.Logger.allowed_levels() do
         Logger.log(level, message)
       end
     end

--- a/lib/json/logger.ex
+++ b/lib/json/logger.ex
@@ -1,4 +1,16 @@
 defmodule Json.Logger do
+  @moduledoc """
+  Exposes separate log level configuration so developers can set logging
+  verbosity for json library
+
+  To configure log level only for json library, add folowing line in config file
+
+      use Mix.Config
+      # to make json be very verbose
+      config :json, log_level: :debug
+      # to make json be silent
+      config :json, log_level: :error
+  """
   require Logger
   @levels [:debug, :info, :warn, :error]
   @level Application.get_env(:json, :log_level, :info)
@@ -14,9 +26,19 @@ defmodule Json.Logger do
                   end)
                   |> Enum.reverse()
 
+  @doc false
   @spec allowed_levels() :: [:debug | :error | :info | :warn, ...]
   def allowed_levels(), do: @allowed_levels
 
+  @doc """
+  Logs given message to logger at given log level
+
+  Supported log levels are:
+  - `:debug` - All messages are logged
+  - `:info` - only :info, :warn and :error messages are logged
+  - `:warn` - only :warn and :error messages are logged
+  - `:error` - only :error messages are logged
+  """
   defmacro log(level, message) do
     quote bind_quoted: [level: level, message: message] do
       if level in Json.Logger.allowed_levels() do

--- a/lib/json/logger.ex
+++ b/lib/json/logger.ex
@@ -26,7 +26,6 @@ defmodule Json.Logger do
                   end)
                   |> Enum.reverse()
 
-  @doc false
   @spec allowed_levels() :: [:debug | :error | :info | :warn, ...]
   def allowed_levels(), do: @allowed_levels
 
@@ -45,5 +44,9 @@ defmodule Json.Logger do
         Logger.log(level, message)
       end
     end
+  end
+
+  def debug(message) do
+    log(:debug, fn -> message end)
   end
 end

--- a/lib/json/logger.ex
+++ b/lib/json/logger.ex
@@ -45,8 +45,4 @@ defmodule Json.Logger do
       end
     end
   end
-
-  def debug(message) do
-    log(:debug, fn -> message end)
-  end
 end

--- a/lib/json/logger.ex
+++ b/lib/json/logger.ex
@@ -1,0 +1,27 @@
+defmodule Json.Logger do
+  require Logger
+  @levels [:debug, :info, :warn, :error]
+  @level Application.get_env(:json, :log_level, :info)
+
+  @allowed_levels @levels
+                  |> Enum.reverse()
+                  |> Enum.reduce_while([], fn l, acc ->
+                    if l == @level do
+                      {:halt, [@level | acc]}
+                    else
+                      {:cont, [l | acc]}
+                    end
+                  end)
+                  |> Enum.reverse()
+
+  @spec allowed_levels() :: [:debug | :error | :info | :warn, ...]
+  def allowed_levels(), do: @allowed_levels
+
+  defmacro log(level, message) do
+    quote bind_quoted: [level: level, message: message] do
+      if level in Json.Logger.allowed_levels() do
+        Logger.log(level, message)
+      end
+    end
+  end
+end

--- a/lib/json/parser.ex
+++ b/lib/json/parser.ex
@@ -70,44 +70,44 @@ defmodule JSON.Parser do
   """
 
   def parse(<<?[, _::binary>> = bin) do
-    log(:debug, "#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)...")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)..." end)
     ArrayParser.parse(bin)
   end
   def parse(<<?{, _::binary>> = bin) do
-    log(:debug, "#{__MODULE__}.parse(bin) starting ObjectParser.parse(bin)...")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) starting ObjectParser.parse(bin)..." end)
     ObjectParser.parse(bin)
   end
   def parse(<<?", _::binary>> = bin) do
-    log(:debug, "#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)...")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)..." end)
     StringParser.parse(bin)
   end
 
   def parse(<<?-, number::utf8, _::binary>> = bin) when number in ?0..?9 do
-    log(:debug, "#{__MODULE__}.parse(bin) starting negative NumberParser.parse(bin)...")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) starting negative NumberParser.parse(bin)..." end)
     NumberParser.parse(bin)
   end
   def parse(<<number::utf8, _::binary>> = bin) when number in ?0..?9 do
-    log(:debug, "#{__MODULE__}.parse(bin) starting NumberParser.parse(bin)...")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) starting NumberParser.parse(bin)..." end)
     NumberParser.parse(bin)
   end
   def parse(<<?n, ?u, ?l, ?l, rest::binary>>) do
-    log(:debug, "#{__MODULE__}.parse(bin) parsed `null` token.")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) parsed `null` token." end)
     {:ok, nil, rest}
   end
   def parse(<<?t, ?r, ?u, ?e, rest::binary>>) do
-    log(:debug, "#{__MODULE__}.parse(bin) parsed `true` token.")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) parsed `true` token." end)
     {:ok, true, rest}
   end
   def parse(<<?f, ?a, ?l, ?s, ?e, rest::binary>>) do
-    log(:debug, "#{__MODULE__}.parse(bin) parsed `false` token.")
+    log(:debug, fn -> "#{__MODULE__}.parse(bin) parsed `false` token." end)
     {:ok, false, rest}
   end
   def parse(<<>>) do
-    log(:debug, "#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
+    log(:debug, fn -> "#{__MODULE__}.parse(<<>>) unexpected end of buffer." end)
     {:error, :unexpected_end_of_buffer}
   end
   def parse(json) do
-    log(:debug, "#{__MODULE__}.parse(json) unexpected token: #{inspect json}")
+    log(:debug, fn -> "#{__MODULE__}.parse(json) unexpected token: #{inspect json}" end)
     {:error, {:unexpected_token, json}}
   end
 end

--- a/lib/json/parser.ex
+++ b/lib/json/parser.ex
@@ -10,6 +10,7 @@ defmodule JSON.Parser do
   alias Parser.String, as: StringParser
 
   require Logger
+  import Json.Logger
 
   @doc """
   parses a valid JSON value, returns its elixir representation
@@ -69,44 +70,44 @@ defmodule JSON.Parser do
   """
 
   def parse(<<?[, _::binary>> = bin) do
-    Logger.debug("#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)...")
+    log(:debug, "#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)...")
     ArrayParser.parse(bin)
   end
   def parse(<<?{, _::binary>> = bin) do
-    Logger.debug("#{__MODULE__}.parse(bin) starting ObjectParser.parse(bin)...")
+    log(:debug, "#{__MODULE__}.parse(bin) starting ObjectParser.parse(bin)...")
     ObjectParser.parse(bin)
   end
   def parse(<<?", _::binary>> = bin) do
-    Logger.debug("#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)...")
+    log(:debug, "#{__MODULE__}.parse(bin) starting ArrayParser.parse(bin)...")
     StringParser.parse(bin)
   end
 
   def parse(<<?-, number::utf8, _::binary>> = bin) when number in ?0..?9 do
-    Logger.debug("#{__MODULE__}.parse(bin) starting negative NumberParser.parse(bin)...")
+    log(:debug, "#{__MODULE__}.parse(bin) starting negative NumberParser.parse(bin)...")
     NumberParser.parse(bin)
   end
   def parse(<<number::utf8, _::binary>> = bin) when number in ?0..?9 do
-    Logger.debug("#{__MODULE__}.parse(bin) starting NumberParser.parse(bin)...")
+    log(:debug, "#{__MODULE__}.parse(bin) starting NumberParser.parse(bin)...")
     NumberParser.parse(bin)
   end
   def parse(<<?n, ?u, ?l, ?l, rest::binary>>) do
-    Logger.debug("#{__MODULE__}.parse(bin) parsed `null` token.")
+    log(:debug, "#{__MODULE__}.parse(bin) parsed `null` token.")
     {:ok, nil, rest}
   end
   def parse(<<?t, ?r, ?u, ?e, rest::binary>>) do
-    Logger.debug("#{__MODULE__}.parse(bin) parsed `true` token.")
+    log(:debug, "#{__MODULE__}.parse(bin) parsed `true` token.")
     {:ok, true, rest}
   end
   def parse(<<?f, ?a, ?l, ?s, ?e, rest::binary>>) do
-    Logger.debug("#{__MODULE__}.parse(bin) parsed `false` token.")
+    log(:debug, "#{__MODULE__}.parse(bin) parsed `false` token.")
     {:ok, false, rest}
   end
   def parse(<<>>) do
-    Logger.debug("#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
+    log(:debug, "#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
     {:error, :unexpected_end_of_buffer}
   end
   def parse(json) do
-    Logger.debug("#{__MODULE__}.parse(json) unexpected token: #{inspect json}")
+    log(:debug, "#{__MODULE__}.parse(json) unexpected token: #{inspect json}")
     {:error, {:unexpected_token, json}}
   end
 end

--- a/lib/json/parser.ex
+++ b/lib/json/parser.ex
@@ -10,7 +10,7 @@ defmodule JSON.Parser do
   alias Parser.String, as: StringParser
 
   require Logger
-  import Json.Logger
+  import JSON.Logger
 
   @doc """
   parses a valid JSON value, returns its elixir representation

--- a/lib/json/parser/array.ex
+++ b/lib/json/parser/array.ex
@@ -32,54 +32,54 @@ defmodule JSON.Parser.Array do
       {:ok, ["foo", 1, 2, 1.5], " lala"}
   """
   def parse(<<?[, rest::binary>>) do
-    debug("#{__MODULE__}.parse(#{inspect rest}) trimming string and the calling parse_array_contents()")
+    log(:debug, fn -> "#{__MODULE__}.parse(#{inspect rest}) trimming string and the calling parse_array_contents()" end)
     rest |> String.trim() |> parse_array_contents()
   end
 
   def parse(<<>>) do
-    debug("#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
+    log(:debug, fn -> "#{__MODULE__}.parse(<<>>) unexpected end of buffer." end)
     {:error, :unexpected_end_of_buffer}
   end
   def parse(json) do
-    debug("#{__MODULE__}.parse(<<>>) unexpected token: #{inspect json}")
+    log(:debug, fn -> "#{__MODULE__}.parse(<<>>) unexpected token: #{inspect json}" end)
     {:error, {:unexpected_token, json}}
   end
 
   # begin parse array
   defp parse_array_contents(json) when is_binary(json) do
-    debug("#{__MODULE__}.parse_array_contents(#{inspect json}) beginning to parse array contents...")
+    log(:debug, fn -> "#{__MODULE__}.parse_array_contents(#{inspect json}) beginning to parse array contents..." end)
     parse_array_contents([], json)
   end
 
   # stop condition
   defp parse_array_contents(acc, <<?], rest::binary>>) do
-    debug("#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect rest}) finished parsing array contents.")
+    log(:debug, fn -> "#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect rest}) finished parsing array contents." end)
     {:ok, Enum.reverse(acc), rest}
   end
 
   # error condition
   defp parse_array_contents(_, <<>>) do
-    debug("#{__MODULE__}.parse_array_contents(acc, <<>>) unexpected end of buffer.")
+    log(:debug, fn -> "#{__MODULE__}.parse_array_contents(acc, <<>>) unexpected end of buffer." end)
     {:error, :unexpected_end_of_buffer}
   end
 
   defp parse_array_contents(acc, json) do
     json |> String.trim() |> Parser.parse() |> case do
       {:error, error_info} ->
-        debug("#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect json}) generated an error: #{inspect error_info}")
+        log(:debug, fn -> "#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect json}) generated an error: #{inspect error_info}" end)
         {:error, error_info}
       {:ok, value, after_value} ->
-        debug("#{__MODULE__}.parse_array_contents(acc, json) sucessfully parsed value `#{inspect value}`, with
-        after_value=#{inspect after_value}")
+        log(:debug, fn -> "#{__MODULE__}.parse_array_contents(acc, json) sucessfully parsed value `#{inspect value}`, with
+        after_value=#{inspect after_value}" end)
         after_value
           |> String.trim()
           |> case do
             <<?,, after_comma::binary>> ->
               trimmed = String.trim(after_comma)
-              debug("#{__MODULE__}.parse_array_contents(acc, json) found a comma, continuing parsing of #{inspect trimmed}")
+              log(:debug, fn -> "#{__MODULE__}.parse_array_contents(acc, json) found a comma, continuing parsing of #{inspect trimmed}" end)
               parse_array_contents([value | acc], trimmed)
             rest ->
-              debug("#{__MODULE__}.parse_array_contents(acc, json) continuing parsing of #{inspect rest}")
+              log(:debug, fn -> "#{__MODULE__}.parse_array_contents(acc, json) continuing parsing of #{inspect rest}" end)
               parse_array_contents([value | acc], rest)
          end
     end

--- a/lib/json/parser/array.ex
+++ b/lib/json/parser/array.ex
@@ -6,6 +6,7 @@ defmodule JSON.Parser.Array do
   alias JSON.Parser, as: Parser
 
   require Logger
+  import Json.Logger
 
   @doc """
   parses a valid JSON array value, returns its elixir list representation
@@ -31,53 +32,53 @@ defmodule JSON.Parser.Array do
       {:ok, ["foo", 1, 2, 1.5], " lala"}
   """
   def parse(<<?[, rest::binary>>) do
-    Logger.debug("#{__MODULE__}.parse(#{inspect rest}) trimming string and the calling parse_array_contents()")
+    log(:debug, "#{__MODULE__}.parse(#{inspect rest}) trimming string and the calling parse_array_contents()")
     rest |> String.trim() |> parse_array_contents()
   end
 
   def parse(<<>>) do
-    Logger.debug("#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
+    log(:debug, "#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
     {:error, :unexpected_end_of_buffer}
   end
   def parse(json) do
-    Logger.debug("#{__MODULE__}.parse(<<>>) unexpected token: #{inspect json}")
+    log(:debug, "#{__MODULE__}.parse(<<>>) unexpected token: #{inspect json}")
     {:error, {:unexpected_token, json}}
   end
 
   # begin parse array
   defp parse_array_contents(json) when is_binary(json) do
-    Logger.debug("#{__MODULE__}.parse_array_contents(#{inspect json}) beginning to parse array contents...")
+    log(:debug, "#{__MODULE__}.parse_array_contents(#{inspect json}) beginning to parse array contents...")
     parse_array_contents([], json)
   end
 
   # stop condition
   defp parse_array_contents(acc, <<?], rest::binary>>) do
-    Logger.debug("#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect rest}) finished parsing array contents.")
+    log(:debug, "#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect rest}) finished parsing array contents.")
     {:ok, Enum.reverse(acc), rest}
   end
 
   # error condition
   defp parse_array_contents(_, <<>>) do
-    Logger.debug("#{__MODULE__}.parse_array_contents(acc, <<>>) unexpected end of buffer.")
+    log(:debug, "#{__MODULE__}.parse_array_contents(acc, <<>>) unexpected end of buffer.")
     {:error, :unexpected_end_of_buffer}
   end
 
   defp parse_array_contents(acc, json) do
     json |> String.trim() |> Parser.parse() |> case do
       {:error, error_info} ->
-        Logger.debug("#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect json}) generated an error: #{inspect error_info}")
+        log(:debug, "#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect json}) generated an error: #{inspect error_info}")
         {:error, error_info}
       {:ok, value, after_value} ->
-        Logger.debug("#{__MODULE__}.parse_array_contents(acc, json) sucessfully parsed value `#{inspect value}`, with
+        log(:debug, "#{__MODULE__}.parse_array_contents(acc, json) sucessfully parsed value `#{inspect value}`, with
         after_value=#{inspect after_value}")
         after_value |> String.trim() |>
           case do
             <<?,, after_comma::binary>> ->
               trimmed = String.trim(after_comma)
-              Logger.debug("#{__MODULE__}.parse_array_contents(acc, json) found a comma, continuing parsing of #{inspect trimmed}")
+              log(:debug, "#{__MODULE__}.parse_array_contents(acc, json) found a comma, continuing parsing of #{inspect trimmed}")
               parse_array_contents([value | acc], trimmed)
             rest ->
-              Logger.debug("#{__MODULE__}.parse_array_contents(acc, json) continuing parsing of #{inspect rest}")
+              log(:debug, "#{__MODULE__}.parse_array_contents(acc, json) continuing parsing of #{inspect rest}")
               parse_array_contents([value | acc], rest)
          end
     end

--- a/lib/json/parser/array.ex
+++ b/lib/json/parser/array.ex
@@ -32,53 +32,54 @@ defmodule JSON.Parser.Array do
       {:ok, ["foo", 1, 2, 1.5], " lala"}
   """
   def parse(<<?[, rest::binary>>) do
-    log(:debug, "#{__MODULE__}.parse(#{inspect rest}) trimming string and the calling parse_array_contents()")
+    debug("#{__MODULE__}.parse(#{inspect rest}) trimming string and the calling parse_array_contents()")
     rest |> String.trim() |> parse_array_contents()
   end
 
   def parse(<<>>) do
-    log(:debug, "#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
+    debug("#{__MODULE__}.parse(<<>>) unexpected end of buffer.")
     {:error, :unexpected_end_of_buffer}
   end
   def parse(json) do
-    log(:debug, "#{__MODULE__}.parse(<<>>) unexpected token: #{inspect json}")
+    debug("#{__MODULE__}.parse(<<>>) unexpected token: #{inspect json}")
     {:error, {:unexpected_token, json}}
   end
 
   # begin parse array
   defp parse_array_contents(json) when is_binary(json) do
-    log(:debug, "#{__MODULE__}.parse_array_contents(#{inspect json}) beginning to parse array contents...")
+    debug("#{__MODULE__}.parse_array_contents(#{inspect json}) beginning to parse array contents...")
     parse_array_contents([], json)
   end
 
   # stop condition
   defp parse_array_contents(acc, <<?], rest::binary>>) do
-    log(:debug, "#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect rest}) finished parsing array contents.")
+    debug("#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect rest}) finished parsing array contents.")
     {:ok, Enum.reverse(acc), rest}
   end
 
   # error condition
   defp parse_array_contents(_, <<>>) do
-    log(:debug, "#{__MODULE__}.parse_array_contents(acc, <<>>) unexpected end of buffer.")
+    debug("#{__MODULE__}.parse_array_contents(acc, <<>>) unexpected end of buffer.")
     {:error, :unexpected_end_of_buffer}
   end
 
   defp parse_array_contents(acc, json) do
     json |> String.trim() |> Parser.parse() |> case do
       {:error, error_info} ->
-        log(:debug, "#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect json}) generated an error: #{inspect error_info}")
+        debug("#{__MODULE__}.parse_array_contents(#{inspect acc}, #{inspect json}) generated an error: #{inspect error_info}")
         {:error, error_info}
       {:ok, value, after_value} ->
-        log(:debug, "#{__MODULE__}.parse_array_contents(acc, json) sucessfully parsed value `#{inspect value}`, with
+        debug("#{__MODULE__}.parse_array_contents(acc, json) sucessfully parsed value `#{inspect value}`, with
         after_value=#{inspect after_value}")
-        after_value |> String.trim() |>
-          case do
+        after_value
+          |> String.trim()
+          |> case do
             <<?,, after_comma::binary>> ->
               trimmed = String.trim(after_comma)
-              log(:debug, "#{__MODULE__}.parse_array_contents(acc, json) found a comma, continuing parsing of #{inspect trimmed}")
+              debug("#{__MODULE__}.parse_array_contents(acc, json) found a comma, continuing parsing of #{inspect trimmed}")
               parse_array_contents([value | acc], trimmed)
             rest ->
-              log(:debug, "#{__MODULE__}.parse_array_contents(acc, json) continuing parsing of #{inspect rest}")
+              debug("#{__MODULE__}.parse_array_contents(acc, json) continuing parsing of #{inspect rest}")
               parse_array_contents([value | acc], rest)
          end
     end

--- a/lib/json/parser/array.ex
+++ b/lib/json/parser/array.ex
@@ -6,7 +6,7 @@ defmodule JSON.Parser.Array do
   alias JSON.Parser, as: Parser
 
   require Logger
-  import Json.Logger
+  import JSON.Logger
 
   @doc """
   parses a valid JSON array value, returns its elixir list representation


### PR DESCRIPTION
Hi,

This change should allow library consumers to set desired log level for json library instead of forcing them to view debug messages for every single function in json lib.