### PR TITLE
Fix compilation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,22 @@ language: elixir
 notifications:
   recipients:
     - carlos@carloslage.net
-elixir:
-  - 1.5
-  - 1.6
-  - 1.7
-  - 1.8
-  - 1.9
-  - 1.10
-  - 1.11
+matrix:
+  include:
+    - elixir: 1.5
+      otp_release: 18.0
+    - elixir: 1.6
+      otp_release: 19.0
+    - elixir: 1.7
+      otp_release: 19.0
+    - elixir: 1.8
+      otp_release: 20.0
+    - elixir: 1.9
+      otp_release: 20.0
+    - elixir: 1.10
+      otp_release: 21.0
+    - elixir: 1.11
+      otp_release: 22.0
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ elixir:
   - 1.6
   - 1.7
   - 1.8
+  - 1.9
+  - 1.10
+  - 1.11
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/lib/json/encoder/default_implementations.ex
+++ b/lib/json/encoder/default_implementations.ex
@@ -170,9 +170,6 @@ defimpl JSON.Encoder, for: Any do
     |> JSON.Encoder.Helpers.dict_encode()
   end
 
-  @doc """
-  Fallback method
-  """
   def encode(x) do
     x
     |> Kernel.inspect()


### PR DESCRIPTION
Hi, I used this library with Elixir 1.11.2 and I found the issue looks like below:

```
==> json
Compiling 13 files (.ex)
warning: redefining @doc attribute previously set at line 164.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head:

    @doc """
    new docs
    """
    def encode(...)

  lib/json/encoder/default_implementations.ex:173: JSON.Encoder.Any.encode/1
```

So, I removed duplicated docs and add some elixir versions for tests.